### PR TITLE
fix a bunch of typos (just a start)

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,7 +1,7 @@
 * Work on the Atlas library
 
 - Make |Split| type use |big_int| fields, at least in the axis language.
-- Fix lack of edge flipping in first (classical) extended block contructor
+- Fix lack of edge flipping in first (classical) extended block constructor
 - Rework |Block_Base| which should not contain "extended" field |orbits|
 - Rewrite block construction using methods inspired by synthetic operations
 - Rewrite K type computations to use data type more compatible with Param
@@ -17,10 +17,10 @@
 
 - Prevent abuse of type system possible by capturing (in functions) variables
   whose type is unsettled (like |[*]|), which by well timed assignments can
-  lead to illegal occurences of |*| (e.g. as type of a concrete value). This
+  lead to illegal occurrences of |*| (e.g. as type of a concrete value). This
   is quite subtle; maybe forbid binding to names with such type altogether.
 
-- Check whether using |braek| or |return| could leave the runtime stack in a
+- Check whether using |break| or |return| could leave the runtime stack in a
   bad state in certain cases, and if so provide chatch blocks to clean up
 
 - give better type error message about "needed type" when a let expression
@@ -40,7 +40,7 @@
 - Implement operate-and-assign directly. While 'v #:= x' (with vec v, int x)
   is easy to write (and common in loop bodies), it is converted to 'v := v#x'
   which is not efficient: with the operation '#' separated in the syntax tree
-  from the assignement ':=', it has no chance of knowing that the same object
+  from the assignment ':=', it has no chance of knowing that the same object
   can be used to store the result, even if the pointer accessing it has the
   lowest possible refcount (which is 2, since the name 'v' must be sharing the
   pointer). This could however be made possible if built-in compound
@@ -66,7 +66,7 @@
 
 * Work on documentation
 
-- Write a tutorial on the axis languge, in bottom-up style
+- Write a tutorial on the axis language, in bottom-up style
 
 * Work on makefiles, distribution and support programs (cwebx)
 - change build process so 'atlas' is ensured to get most recent version string

--- a/doc/modules
+++ b/doc/modules
@@ -33,7 +33,7 @@ Utilities.
   Level 2: constructions that relate to or use basic data types
 
   permutations	permutations, and their actions on (bit)vectors and matrices
-  partition	parition of an interval, orbits (uses bitmap, comparison)
+  partition	partition of an interval, orbits (uses bitmap, comparison)
   poset		posets, hasse diagrams (uses graph)
   matreduc	matrix echelon algorithms, Smith form
 
@@ -67,7 +67,7 @@ gKmod
   kgb		classes for one-sided parameters (elements of K\G/B)
   descents	header-only module defining the |DescentStatus| class
   blocks	classes for two-sided parameters
-  klsupport	a base class for KL computations, streamlining block acces
+  klsupport	a base class for KL computations, streamlining block access
   wgraph	a class storing a W graph, and decomposition of it
   kl		the main KL computation (class KLContext)
   standardrepk  standard representations restricted to K: multiple classes
@@ -129,7 +129,7 @@ Standalone
   matstat	gathering statistics on the KL matrix
   polstat	gathering statistics on the KL polynomials
 
-Interpeter	The realex program
+Interpreter	The realex program
 
   buffer	input buffer class
   lexer		lexical analyser

--- a/doc/structure.bib
+++ b/doc/structure.bib
@@ -19,7 +19,7 @@
 author = {A.V. {Aho, R. Seti and J.D. Ullman}},
 title = {{Compilers}},
 publisher = {Addison-Wesley},
-address = {Reading, Massachussets},
+address = {Reading, Massachusetts},
 year = {1986}
 }
 

--- a/messages/Ktypemat.help
+++ b/messages/Ktypemat.help
@@ -19,7 +19,7 @@ as in the Ktypeform command. The software tests if this is both
 final); if not it prints a message and quits. If so, the user is told
 the height of this representation, and asked for a height bound.
 
-The software first converts the paramter into normal final standard
+The software first converts the parameter into normal final standard
 form. It then computes all K-types of this representation up to the
 given height. Each of these K-types is parametrized by a normal final
 standard module, and each of the K-types of these are also computed,
@@ -110,7 +110,7 @@ Triangular system:
   0 -1  1  0  0
   0  0 -1  1  0
   0  0  0 -1  1
-Matrix of K-type multiplicites:
+Matrix of K-type multiplicities:
   1  0  0  0  0
   1  1  0  0  0
   1  1  1  0  0
@@ -156,7 +156,7 @@ Triangular system:
   0  0 -1  0  1  0  0
   0  0  0 -1  0  1  0
   0  0  0  0 -1  0  1
-Matrix of K-type multiplicites:
+Matrix of K-type multiplicities:
   1  0  0  0  0  0  0
   1  1  0  0  0  0  0
   1  0  1  0  0  0  0
@@ -196,7 +196,7 @@ Triangular system:
  -1  0  0  1  0  0
  -1 -1  0  0  1  0
  -1  0  0  0  0  1
-Matrix of K-type multiplicites:
+Matrix of K-type multiplicities:
   1  0  0  0  0  0
   1  1  0  0  0  0
   2  1  1  0  0  0

--- a/messages/X.help
+++ b/messages/X.help
@@ -6,7 +6,7 @@ For this reason it does not require selecting a real form, it just requires
 (and asks for if not already known) a complex group and an inner class.
 
 The output format, apart from the very first line, is similar to that of KGB,
-to which we refer for more details; the succesive columns give a sequence
+to which we refer for more details; the successive columns give a sequence
 number, a length, the statuses of all simple roots at this element, the cross
 action links, the Cayley transform links, a rational vector that distinguishes
 elements lying over the same involution, the Cartan class, and the involution.
@@ -90,9 +90,9 @@ Base grading: [111].
 
 
 We see that the X structure has 19 elements, and the KGB structures have 3 and
-13 elements respectively. In fact the KGB struture for the real form sl(2,H)
-is present in the X structre twice: once as lines 2,6,12 and once as lines
-3,7,13. The remaining lines corresponde to the KGB for the real form sl(4,R).
+13 elements respectively. In fact the KGB structure for the real form sl(2,H)
+is present in the X structure twice: once as lines 2,6,12 and once as lines
+3,7,13. The remaining lines correspond to the KGB for the real form sl(4,R).
 
 We can check using 'strongreal' that on Cartan class #0 the real form #0 is
 present with two distinct strong real forms

--- a/messages/extract-cells.help
+++ b/messages/extract-cells.help
@@ -1,7 +1,7 @@
 
 The "extract-cells" command provides the same information as the "wcells"
 command, however without explicitly computing the block and Kazhdan-Lusztig
-information. It is therefore necessary to have this infomation available in
+information. It is therefore necessary to have this information available in
 the form of three binary files; the command will prompt for their names. Such
 files can be produced by the commands "blockwrite" (the block information
 file) and "klwrite" (the matrix information and polynomial information files).

--- a/messages/extract-graph.help
+++ b/messages/extract-graph.help
@@ -1,7 +1,7 @@
 
 The "extract-graph" command provides the same information as the "wgraph"
 command, however without explicitly computing the block and Kazhdan-Lusztig
-information. It is therefore necessary to have this infomation available in
+information. It is therefore necessary to have this information available in
 the form of three binary files; the command will prompt for their names. Such
 files can be produced by the commands "blockwrite" (the block information
 file) and "klwrite" (the matrix information and polynomial information files).

--- a/messages/kgbgraph.help
+++ b/messages/kgbgraph.help
@@ -7,7 +7,7 @@ program 'dot' available from
 
 http://www.graphviz.org.
 
-Use the commands 'kgb' and 'kgborder' to view this infomation
+Use the commands 'kgb' and 'kgborder' to view this information
 in plain text form.
 
 The software will prompt the user for a real form if it has not

--- a/messages/kgpgraph.help
+++ b/messages/kgpgraph.help
@@ -6,7 +6,7 @@ visualization program 'dot' available from
 
 http://www.graphviz.org.
 
-Use the commands 'kgp' and 'kgporder' to view this infomation
+Use the commands 'kgp' and 'kgporder' to view this information
 in plain text form.
 
 The software will prompt the user for a realform if it has not

--- a/messages/nblock.help
+++ b/messages/nblock.help
@@ -28,7 +28,7 @@ nodes for such a factor in the usual Bourbaki ordering. When this happens,
 it is important to note that the subsystem generators nonetheless remain
 internally ordered by increasing number rather than by Lie type factor.
 This is important in interpreting cross action and Cayley links in the
-block output. So when, in a F4 situtation, Fokko would print
+block output. So when, in a F4 situation, Fokko would print
 
 "Subsystem on dual side is of type A2.A2, with roots 28,39,29,38."
 

--- a/messages/rootdatum.help
+++ b/messages/rootdatum.help
@@ -27,12 +27,12 @@ See the help file for the cmatrix command
 
 2) root basis
 
-The columnns give the simple roots in the given basis, as in the
+The columns give the simple roots in the given basis, as in the
 output of the roots and posroots commands.
 
 3) coroot basis
 
-The columnns give the simple coroots in the given basis, as in the
+The columns give the simple coroots in the given basis, as in the
 output of the coroots and poscoroots commands.
 
 4) radical basis
@@ -111,7 +111,7 @@ positive coroots :
 Example: root datum of GL(3)
 
 Since G is neither simply connected nor adjoint the bases of X^*(T)
-and X_*(T) are not partcularly nice. Both the root and coroot basis
+and X_*(T) are not particularly nice. Both the root and coroot basis
 matrices have 3 rows (rank 3) and 2 columns (semisimple rank 2).
 
 main: type

--- a/sources/Atlas.h
+++ b/sources/Atlas.h
@@ -23,7 +23,7 @@
  BEFORE any of the utility forward files (the ones whose inclusion is excleded
  below) are invoked; this can be accomplished by including it before any other
  Atlas files in each non-utility header file. (Header or other files in the
- utility sub-directory itself should not include ot otherwise refer to this
+ utility sub-directory itself should not include or otherwise refer to this
  file, so as to retain their independence of the rest of the Atlas project.) In
  this manner those object files avoid including both such a forward file and its
  information duplicated here. Since the utility object files necessarily do use
@@ -76,7 +76,7 @@ namespace atlas {
    were simply replaced by this file, avoiding duplication, but the utilities
    modules have the ambition of being reusable independently of the rest of
    the Atlas library. In fact this file should always be included in any Atlas
-   header file other than from the utilitites subdirectory, and alway before
+   header file other than from the utilitites subdirectory, and always before
    any header files from that subdirectory, so the definitions here will be
    the only ones seen when compiling the Atlas library.
  */

--- a/sources/stand-alone/matstat.cpp
+++ b/sources/stand-alone/matstat.cpp
@@ -22,7 +22,7 @@ namespace atlas {
 
 typedef tally::TallyVec<unsigned char> tally_vec;
 
-/* A function that computes the vector saying for any strongly primitve
+/* A function that computes the vector saying for any strongly primitive
    element $x$ for $y$ how many $x_0$'s primitivise to $x$ for $y$.
 */
 std::vector<unsigned int>


### PR DESCRIPTION
hello,
I have just found typos using the tool
```
sage --tox -e codespell .
```
I have fixed a few ones. I can go on fixing more if you merge this pull request.